### PR TITLE
Use wget's built in --reject flag

### DIFF
--- a/lib/accesslint/ci/scanner.rb
+++ b/lib/accesslint/ci/scanner.rb
@@ -46,9 +46,9 @@ module Accesslint
           wget #{host} 2>&1 \
             --spider \
             --recursive \
+            --reject css,png,gif,jpg,jpeg,svg,ico,txt,woff \
             | grep '^--' \
             | awk '{ print $3 }' \
-            | grep -v '\.\(css\|js\|png\|gif\|jpg\|svg\|ico\|txt\|woff\)$' \
             | sort \
             | uniq \
             | xargs -n1 accesslint \


### PR DESCRIPTION
- Instead of filtering media types after the fact, instruct wget not to
  crawl them to begin with.