### PR TITLE
Ignore robots.txt

### DIFF
--- a/lib/accesslint/ci/scanner.rb
+++ b/lib/accesslint/ci/scanner.rb
@@ -47,6 +47,7 @@ module Accesslint
             --spider \
             --recursive \
             --reject css,png,gif,jpg,jpeg,svg,ico,txt,woff \
+            -erobots=off \
             | grep '^--' \
             | awk '{ print $3 }' \
             | sort \


### PR DESCRIPTION
- The assumption is that we're running this in CI against our own
  projects, so we can crawl the site without respecting robots.txt.